### PR TITLE
Replace rowing sliders with numeric inputs (min/max hints)

### DIFF
--- a/src/app/settings-dialog/rowing-settings.component.html
+++ b/src/app/settings-dialog/rowing-settings.component.html
@@ -81,12 +81,18 @@
                     }
                 </mat-form-field>
 
-                <div class="slider-container">
-                    <span>Impulses Per Revolution:</span>
-                    <mat-slider min="1" max="12" step="1" discrete>
-                        <input matSliderThumb formControlName="impulsePerRevolution" />
-                    </mat-slider>
-                </div>
+                <mat-form-field>
+                    <mat-label>Impulses Per Revolution</mat-label>
+                    <input
+                        matInput
+                        formControlName="impulsePerRevolution"
+                        type="number"
+                        min="1"
+                        max="12"
+                        step="1"
+                    />
+                    <mat-hint align="end">Min 1 • Max 12</mat-hint>
+                </mat-form-field>
             </div>
         </mat-expansion-panel>
 
@@ -100,8 +106,7 @@
                 }
             </mat-expansion-panel-header>
             <div class="expansion-content" formGroupName="sensorSignalSettings">
-                <div
-                    class="slider-container"
+                <mat-form-field
                     matTooltip="Minimum value depends on drag factor recovery period"
                     [matTooltipDisabled]="
                         settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value !==
@@ -109,26 +114,39 @@
                     "
                     matTooltipShowDelay="1000"
                 >
-                    <span>Rotation Debounce (ms):</span>
-                    <mat-slider
+                    <mat-label>Rotation Debounce (ms)</mat-label>
+                    <input
+                        matInput
+                        formControlName="rotationDebounceTime"
+                        type="number"
                         [min]="
                             settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod
                                 .value
                         "
                         max="50"
                         step="1"
-                        discrete
-                    >
-                        <input matSliderThumb formControlName="rotationDebounceTime" />
-                    </mat-slider>
-                </div>
+                    />
+                    <mat-hint align="end">
+                        Min
+                        {{
+                            settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value
+                        }}
+                        • Max 50
+                    </mat-hint>
+                </mat-form-field>
 
-                <div class="slider-container">
-                    <span>Rowing Stop Threshold (sec):</span>
-                    <mat-slider min="4" max="20" step="1" discrete>
-                        <input matSliderThumb formControlName="rowingStoppedThreshold" />
-                    </mat-slider>
-                </div>
+                <mat-form-field>
+                    <mat-label>Rowing Stop Threshold (sec)</mat-label>
+                    <input
+                        matInput
+                        formControlName="rowingStoppedThreshold"
+                        type="number"
+                        min="4"
+                        max="20"
+                        step="1"
+                    />
+                    <mat-hint align="end">Min 4 • Max 20</mat-hint>
+                </mat-form-field>
             </div>
         </mat-expansion-panel>
 
@@ -180,8 +198,7 @@
                     }
                 </mat-form-field>
 
-                <div
-                    class="slider-container"
+                <mat-form-field
                     matTooltip="Maximum value depends on the rotation debounce time"
                     [matTooltipDisabled]="
                         settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value !==
@@ -189,39 +206,54 @@
                     "
                     matTooltipShowDelay="1000"
                 >
-                    <span>Drag Factor Period:</span>
-                    <mat-slider
+                    <mat-label>Drag Factor Period</mat-label>
+                    <input
+                        matInput
+                        formControlName="maxDragFactorRecoveryPeriod"
+                        type="number"
                         min="1"
                         [max]="settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value"
                         step="1"
-                        discrete
-                    >
-                        <input matSliderThumb formControlName="maxDragFactorRecoveryPeriod" />
-                    </mat-slider>
+                    />
+                    <mat-hint align="end">
+                        Min 1 • Max
+                        {{ settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value }}
+                    </mat-hint>
                     @if (settingsFormErrors()?.maxDragFactorRecoveryPeriodExceeded) {
                         <mat-error>Value yields too many data points (max 1000)</mat-error>
                     }
-                </div>
+                </mat-form-field>
 
-                <div class="slider-container">
-                    <span>Drag Coefficients Array Size:</span>
-                    <mat-slider min="1" max="15" step="1" discrete>
-                        <input matSliderThumb formControlName="dragCoefficientsArrayLength" />
-                    </mat-slider>
-                </div>
+                <mat-form-field>
+                    <mat-label>Drag Coefficients Array Size</mat-label>
+                    <input
+                        matInput
+                        formControlName="dragCoefficientsArrayLength"
+                        type="number"
+                        min="1"
+                        max="15"
+                        step="1"
+                    />
+                    <mat-hint align="end">Min 1 • Max 15</mat-hint>
+                </mat-form-field>
 
-                <div class="slider-container gt-xs-grid-span-2">
-                    <span>Goodness of Fit Threshold:</span>
-                    <mat-slider
+                <mat-form-field class="gt-xs-grid-span-2">
+                    <mat-label>Goodness of Fit Threshold</mat-label>
+                    <input
+                        matInput
+                        formControlName="goodnessOfFitThreshold"
+                        type="number"
                         min="0"
                         [max]="254 / 255"
-                        [step]="1 / 255"
-                        discrete
-                        [displayWith]="formatPercent"
-                    >
-                        <input matSliderThumb formControlName="goodnessOfFitThreshold" />
-                    </mat-slider>
-                </div>
+                        step="0.001"
+                    />
+                    <mat-hint align="start">
+                        Min 0 • Max {{ 254 / 255 | number: "1.3-3" }}
+                    </mat-hint>
+                    <mat-hint align="end">
+                        {{ formatPercent(settingsForm.controls.dragFactorSettings.controls.goodnessOfFitThreshold.value) }}
+                    </mat-hint>
+                </mat-form-field>
             </div>
         </mat-expansion-panel>
 
@@ -242,17 +274,21 @@
                     </mat-select>
                 </mat-form-field>
 
-                <div class="slider-container" [class.new-impulse-array]="!showMinimumRecoverySlopeMargin()">
-                    <span>Impulse Data Array Size:</span>
-                    <mat-slider
+                <mat-form-field [class.new-impulse-array]="!showMinimumRecoverySlopeMargin()">
+                    <mat-label>Impulse Data Array Size</mat-label>
+                    <input
+                        matInput
+                        formControlName="impulseDataArrayLength"
+                        type="number"
                         min="1"
                         [max]="rowerSettings().generalSettings.isCompiledWithDouble ? 15 : 18"
                         step="1"
-                        discrete
-                    >
-                        <input matSliderThumb formControlName="impulseDataArrayLength" />
-                    </mat-slider>
-                </div>
+                    />
+                    <mat-hint align="end">
+                        Min 1 • Max
+                        {{ rowerSettings().generalSettings.isCompiledWithDouble ? 15 : 18 }}
+                    </mat-hint>
+                </mat-form-field>
 
                 <mat-form-field>
                     <mat-label>Minimum Powered Torque</mat-label>
@@ -380,12 +416,18 @@
                     }
                 </mat-form-field>
 
-                <div class="slider-container gt-xs-grid-span-2">
-                    <span>Drive Handle Forces Size:</span>
-                    <mat-slider min="0" max="255" step="1" discrete>
-                        <input matSliderThumb formControlName="driveHandleForcesMaxCapacity" />
-                    </mat-slider>
-                </div>
+                <mat-form-field class="gt-xs-grid-span-2">
+                    <mat-label>Drive Handle Forces Size</mat-label>
+                    <input
+                        matInput
+                        formControlName="driveHandleForcesMaxCapacity"
+                        type="number"
+                        min="0"
+                        max="255"
+                        step="1"
+                    />
+                    <mat-hint align="end">Min 0 • Max 255</mat-hint>
+                </mat-form-field>
             </div>
         </mat-expansion-panel>
     </mat-accordion>

--- a/src/app/settings-dialog/rowing-settings.component.html
+++ b/src/app/settings-dialog/rowing-settings.component.html
@@ -81,18 +81,18 @@
                     }
                 </mat-form-field>
 
-                <mat-form-field>
-                    <mat-label>Impulses Per Revolution</mat-label>
-                    <input
-                        matInput
-                        formControlName="impulsePerRevolution"
-                        type="number"
-                        min="1"
-                        max="12"
-                        step="1"
-                    />
-                    <mat-hint align="end">Min 1 • Max 12</mat-hint>
-                </mat-form-field>
+                <div class="slider-container">
+                    <span>Impulses Per Revolution:</span>
+                    <div class="slider-row">
+                        <mat-slider min="1" max="12" step="1">
+                            <input matSliderThumb formControlName="impulsePerRevolution" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.machineSettings.controls.impulsePerRevolution.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">Min 1 • Max 12</div>
+                </div>
             </div>
         </mat-expansion-panel>
 
@@ -106,47 +106,42 @@
                 }
             </mat-expansion-panel-header>
             <div class="expansion-content" formGroupName="sensorSignalSettings">
-                <mat-form-field
-                    matTooltip="Minimum value depends on drag factor recovery period"
-                    [matTooltipDisabled]="
-                        settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value !==
-                        settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value
-                    "
-                    matTooltipShowDelay="1000"
-                >
-                    <mat-label>Rotation Debounce (ms)</mat-label>
-                    <input
-                        matInput
-                        formControlName="rotationDebounceTime"
-                        type="number"
-                        [min]="
-                            settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod
-                                .value
-                        "
-                        max="50"
-                        step="1"
-                    />
-                    <mat-hint align="end">
+                <div class="slider-container">
+                    <span>Rotation Debounce (ms):</span>
+                    <div class="slider-row">
+                        <mat-slider
+                            [min]="
+                                settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod
+                                    .value
+                            "
+                            max="50"
+                            step="1"
+                        >
+                            <input matSliderThumb formControlName="rotationDebounceTime" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">
                         Min
-                        {{
-                            settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value
-                        }}
+                        {{ settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value }}
                         • Max 50
-                    </mat-hint>
-                </mat-form-field>
+                    </div>
+                </div>
 
-                <mat-form-field>
-                    <mat-label>Rowing Stop Threshold (sec)</mat-label>
-                    <input
-                        matInput
-                        formControlName="rowingStoppedThreshold"
-                        type="number"
-                        min="4"
-                        max="20"
-                        step="1"
-                    />
-                    <mat-hint align="end">Min 4 • Max 20</mat-hint>
-                </mat-form-field>
+                <div class="slider-container">
+                    <span>Rowing Stop Threshold (sec):</span>
+                    <div class="slider-row">
+                        <mat-slider min="4" max="20" step="1">
+                            <input matSliderThumb formControlName="rowingStoppedThreshold" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.sensorSignalSettings.controls.rowingStoppedThreshold.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">Min 4 • Max 20</div>
+                </div>
             </div>
         </mat-expansion-panel>
 
@@ -198,62 +193,59 @@
                     }
                 </mat-form-field>
 
-                <mat-form-field
-                    matTooltip="Maximum value depends on the rotation debounce time"
-                    [matTooltipDisabled]="
-                        settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value !==
-                        settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value
-                    "
-                    matTooltipShowDelay="1000"
-                >
-                    <mat-label>Drag Factor Period</mat-label>
-                    <input
-                        matInput
-                        formControlName="maxDragFactorRecoveryPeriod"
-                        type="number"
-                        min="1"
-                        [max]="settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value"
-                        step="1"
-                    />
-                    <mat-hint align="end">
-                        Min 1 • Max
-                        {{ settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value }}
-                    </mat-hint>
+                <div class="slider-container">
+                    <span>Drag Factor Period:</span>
+                    <div class="slider-row">
+                        <mat-slider
+                            min="1"
+                            [max]="settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value"
+                            step="1"
+                        >
+                            <input matSliderThumb formControlName="maxDragFactorRecoveryPeriod" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.dragFactorSettings.controls.maxDragFactorRecoveryPeriod.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">
+                        Min 1 • Max {{ settingsForm.controls.sensorSignalSettings.controls.rotationDebounceTime.value }}
+                    </div>
                     @if (settingsFormErrors()?.maxDragFactorRecoveryPeriodExceeded) {
                         <mat-error>Value yields too many data points (max 1000)</mat-error>
                     }
-                </mat-form-field>
+                </div>
 
-                <mat-form-field>
-                    <mat-label>Drag Coefficients Array Size</mat-label>
-                    <input
-                        matInput
-                        formControlName="dragCoefficientsArrayLength"
-                        type="number"
-                        min="1"
-                        max="15"
-                        step="1"
-                    />
-                    <mat-hint align="end">Min 1 • Max 15</mat-hint>
-                </mat-form-field>
+                <div class="slider-container">
+                    <span>Drag Coefficients Array Size:</span>
+                    <div class="slider-row">
+                        <mat-slider min="1" max="15" step="1">
+                            <input matSliderThumb formControlName="dragCoefficientsArrayLength" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.dragFactorSettings.controls.dragCoefficientsArrayLength.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">Min 1 • Max 15</div>
+                </div>
 
-                <mat-form-field class="gt-xs-grid-span-2">
-                    <mat-label>Goodness of Fit Threshold</mat-label>
-                    <input
-                        matInput
-                        formControlName="goodnessOfFitThreshold"
-                        type="number"
-                        min="0"
-                        [max]="254 / 255"
-                        step="0.001"
-                    />
-                    <mat-hint align="start">
-                        Min 0 • Max {{ 254 / 255 | number: "1.3-3" }}
-                    </mat-hint>
-                    <mat-hint align="end">
-                        {{ formatPercent(settingsForm.controls.dragFactorSettings.controls.goodnessOfFitThreshold.value) }}
-                    </mat-hint>
-                </mat-form-field>
+                <div class="slider-container gt-xs-grid-span-2">
+                    <span>Goodness of Fit Threshold:</span>
+                    <div class="slider-row">
+                        <mat-slider min="0" [max]="254 / 255" [step]="1 / 255">
+                            <input matSliderThumb formControlName="goodnessOfFitThreshold" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{
+                                formatPercent(
+                                    settingsForm.controls.dragFactorSettings.controls.goodnessOfFitThreshold.value
+                                )
+                            }}
+                        </span>
+                    </div>
+                    <div class="slider-range">
+                        Min 0 • Max 99
+                    </div>
+                </div>
             </div>
         </mat-expansion-panel>
 
@@ -274,21 +266,25 @@
                     </mat-select>
                 </mat-form-field>
 
-                <mat-form-field [class.new-impulse-array]="!showMinimumRecoverySlopeMargin()">
-                    <mat-label>Impulse Data Array Size</mat-label>
-                    <input
-                        matInput
-                        formControlName="impulseDataArrayLength"
-                        type="number"
-                        min="1"
-                        [max]="rowerSettings().generalSettings.isCompiledWithDouble ? 15 : 18"
-                        step="1"
-                    />
-                    <mat-hint align="end">
+                <div class="slider-container" [class.new-impulse-array]="!showMinimumRecoverySlopeMargin()">
+                    <span>Impulse Data Array Size:</span>
+                    <div class="slider-row">
+                        <mat-slider
+                            min="1"
+                            [max]="rowerSettings().generalSettings.isCompiledWithDouble ? 15 : 18"
+                            step="1"
+                        >
+                            <input matSliderThumb formControlName="impulseDataArrayLength" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.strokeDetectionSettings.controls.impulseDataArrayLength.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">
                         Min 1 • Max
                         {{ rowerSettings().generalSettings.isCompiledWithDouble ? 15 : 18 }}
-                    </mat-hint>
-                </mat-form-field>
+                    </div>
+                </div>
 
                 <mat-form-field>
                     <mat-label>Minimum Powered Torque</mat-label>
@@ -416,18 +412,18 @@
                     }
                 </mat-form-field>
 
-                <mat-form-field class="gt-xs-grid-span-2">
-                    <mat-label>Drive Handle Forces Size</mat-label>
-                    <input
-                        matInput
-                        formControlName="driveHandleForcesMaxCapacity"
-                        type="number"
-                        min="0"
-                        max="255"
-                        step="1"
-                    />
-                    <mat-hint align="end">Min 0 • Max 255</mat-hint>
-                </mat-form-field>
+                <div class="slider-container gt-xs-grid-span-2">
+                    <span>Drive Handle Forces Size:</span>
+                    <div class="slider-row">
+                        <mat-slider min="0" max="255" step="1">
+                            <input matSliderThumb formControlName="driveHandleForcesMaxCapacity" />
+                        </mat-slider>
+                        <span class="slider-value">
+                            {{ settingsForm.controls.strokeDetectionSettings.controls.driveHandleForcesMaxCapacity.value }}
+                        </span>
+                    </div>
+                    <div class="slider-range">Min 0 • Max 255</div>
+                </div>
             </div>
         </mat-expansion-panel>
     </mat-accordion>

--- a/src/app/settings-dialog/rowing-settings.component.scss
+++ b/src/app/settings-dialog/rowing-settings.component.scss
@@ -44,7 +44,34 @@
     }
 
     .mat-mdc-slider {
-        margin: 0px 4px;
+        margin: 0 0 0 4px;
+    }
+
+    .slider-row {
+        display: flex;
+        align-items: center;
+        gap: 0;
+    }
+
+    .slider-row .mat-mdc-slider {
+        flex: 1 1 auto;
+        min-width: 0;
+        filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.22));
+    }
+
+    .slider-value {
+        min-width: 0;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        font-size: 0.9rem;
+        margin-left: 14px;
+    }
+
+    .slider-range {
+        margin-left: 4px;
+        font-size: 0.75rem;
+        color: rgba(0, 0, 0, 0.6);
+        font-variant-numeric: tabular-nums;
     }
 }
 

--- a/src/app/settings-dialog/rowing-settings.component.ts
+++ b/src/app/settings-dialog/rowing-settings.component.ts
@@ -33,10 +33,9 @@ import {
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
 } from "@angular/material/expansion";
-import { MatError, MatFormField, MatLabel } from "@angular/material/form-field";
+import { MatError, MatFormField, MatHint, MatLabel } from "@angular/material/form-field";
 import { MatInput } from "@angular/material/input";
 import { MatSelect } from "@angular/material/select";
-import { MatSliderModule } from "@angular/material/slider";
 import { MatTooltip } from "@angular/material/tooltip";
 import { map, startWith } from "rxjs";
 
@@ -98,11 +97,11 @@ export type RowingSettingsFormGroup = FormGroup<{
         KeyValuePipe,
         MatError,
         MatFormField,
+        MatHint,
         MatLabel,
         MatSelect,
         MatOption,
         MatInput,
-        MatSliderModule,
         MatButton,
         MatAccordion,
         MatExpansionPanel,


### PR DESCRIPTION
## Summary
  - Replace sliders in the Rowing tab with numeric input fields
  - Show explicit min/max hints for each value
  
  ## Motivation
  Sliders are especially frustrating to use on smartphones and make precise values hard to enter.
  They are also difficult to read when discussing settings on GitHub, because exact values
  are not immediately visible and require extra effort to extract.