### PR TITLE
Add settings export with profile naming

### DIFF
--- a/src/app/settings-dialog/settings-dialog.component.html
+++ b/src/app/settings-dialog/settings-dialog.component.html
@@ -28,8 +28,32 @@
             </app-rowing-settings>
         </mat-tab>
     </mat-tab-group>
+
+    @if (currentTabIndex() === 0) {
+        <div class="export-name-row">
+            <mat-form-field subscriptSizing="dynamic">
+                <mat-label>Export Profile Name</mat-label>
+                <input
+                    matInput
+                    [formControl]="exportProfileNameControl"
+                    maxlength="60"
+                    placeholder="e.g. My Home Rower"
+                />
+                <mat-hint align="start">Required for export</mat-hint>
+                <mat-hint align="end">Max 60</mat-hint>
+            </mat-form-field>
+        </div>
+    }
 </div>
 <div mat-dialog-actions align="end">
+    <button
+        (click)="exportSettings()"
+        mat-stroked-button
+        type="button"
+        [disabled]="exportProfileNameControl.invalid"
+    >
+        Export
+    </button>
     <button (click)="saveSettings()" mat-raised-button [disabled]="!isSaveButtonEnabled()">Save</button>
     <button (click)="handleDialogClose()" mat-raised-button>Cancel</button>
 </div>

--- a/src/app/settings-dialog/settings-dialog.component.html
+++ b/src/app/settings-dialog/settings-dialog.component.html
@@ -50,7 +50,7 @@
         (click)="exportSettings()"
         mat-stroked-button
         type="button"
-        [disabled]="exportProfileNameControl.invalid"
+        [disabled]="exportProfileNameControl.invalid || data.ergConnectionStatus.status !== 'connected'"
     >
         Export
     </button>

--- a/src/app/settings-dialog/settings-dialog.component.scss
+++ b/src/app/settings-dialog/settings-dialog.component.scss
@@ -2,3 +2,8 @@ h4 {
     margin-bottom: 0px;
     margin-top: 0px;
 }
+
+.export-name-row {
+    margin-top: 12px;
+    margin-bottom: 8px;
+}

--- a/src/app/settings-dialog/settings-dialog.component.spec.ts
+++ b/src/app/settings-dialog/settings-dialog.component.spec.ts
@@ -446,13 +446,15 @@ describe("SettingsDialogComponent", (): void => {
         it("should have proper buttons with correct state", async (): Promise<void> => {
             const dialogActions = fixture.debugElement.nativeElement.querySelector("[mat-dialog-actions]");
             const buttons = dialogActions.querySelectorAll("button");
-            expect(buttons).toHaveLength(2);
+            expect(buttons).toHaveLength(3);
 
-            const saveButton = dialogActions.querySelector("button[ng-reflect-disabled]") || buttons[0];
-            const cancelButton = buttons[1];
+            const exportButton = buttons[0];
+            const saveButton = dialogActions.querySelector("button[ng-reflect-disabled]") || buttons[1];
+            const cancelButton = buttons[2];
 
             expect(saveButton.textContent.trim()).toBe("Save");
             expect(cancelButton.textContent.trim()).toBe("Cancel");
+            expect(exportButton.textContent.trim()).toBe("Export");
 
             setupMockChildComponents(false, false, false);
             component.onGeneralFormValidityChange(true);

--- a/src/app/settings-dialog/settings-dialog.component.ts
+++ b/src/app/settings-dialog/settings-dialog.component.ts
@@ -119,6 +119,9 @@ export class SettingsDialogComponent {
             nonNullable: true,
             validators: [Validators.required, Validators.maxLength(60)],
         });
+        if (this.data.ergConnectionStatus.status !== "connected") {
+            this.exportProfileNameControl.disable({ emitEvent: false });
+        }
 
         this.breakPoints$.pipe(takeUntilDestroyed()).subscribe((isSmallScreen: boolean): void => {
             if (isSmallScreen) {
@@ -209,6 +212,14 @@ export class SettingsDialogComponent {
 
     async exportSettings(): Promise<void> {
         try {
+            if (this.data.ergConnectionStatus.status !== "connected") {
+                this.snackBar.open("Connect to a device before exporting settings", "Dismiss", {
+                    duration: 3000,
+                });
+
+                return;
+            }
+
             const profileName = this.getExportProfileName();
             if (!profileName) {
                 this.snackBar.open("Please provide a profile name for export", "Dismiss", {
@@ -219,10 +230,11 @@ export class SettingsDialogComponent {
 
             const generalForm = this.generalSettings().getForm();
             const rowingForm = this.rowingSettings().getForm();
+            const exportedAtIso = new Date().toISOString();
 
             const payload: ISettingsExport = {
                 schemaVersion: 1,
-                exportedAt: new Date().toISOString(),
+                exportedAt: exportedAtIso,
                 appBuildTimestamp: versionInfo.timeStamp,
                 profileName,
                 deviceInfo: this.data.deviceInfo,
@@ -236,7 +248,7 @@ export class SettingsDialogComponent {
                 rowingSettings: rowingForm.getRawValue(),
             };
 
-            const fileName = this.buildExportFilename(payload.profileName, payload.exportedAt);
+            const fileName = this.buildExportFilename(payload.profileName, exportedAtIso);
             const blob = new Blob([JSON.stringify(payload, null, 2)], {
                 type: "application/json",
             });
@@ -377,17 +389,7 @@ export class SettingsDialogComponent {
     }
 
     private formatExportTimestamp(isoTimestamp: string): string {
-        const date = new Date(isoTimestamp);
-
-        const pad = (value: number): string => value.toString().padStart(2, "0");
-
-        const year = date.getFullYear();
-        const month = pad(date.getMonth() + 1);
-        const day = pad(date.getDate());
-        const hours = pad(date.getHours());
-        const minutes = pad(date.getMinutes());
-
-        return `${year}-${month}-${day}_${hours}-${minutes}`;
+        return isoTimestamp.replace(/[:.]/g, "-");
     }
 
     private getExportProfileName(): string | undefined {

--- a/src/app/settings-dialog/settings-dialog.component.ts
+++ b/src/app/settings-dialog/settings-dialog.component.ts
@@ -11,6 +11,7 @@ import {
     WritableSignal,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormControl, ReactiveFormsModule, Validators } from "@angular/forms";
 import { MatButton } from "@angular/material/button";
 import {
     MAT_DIALOG_DATA,
@@ -19,12 +20,15 @@ import {
     MatDialogRef,
     MatDialogTitle,
 } from "@angular/material/dialog";
+import { MatFormField, MatHint, MatLabel } from "@angular/material/form-field";
+import { MatInput } from "@angular/material/input";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { MatTab, MatTabGroup } from "@angular/material/tabs";
 import { firstValueFrom, map, Observable } from "rxjs";
 
 import { IDeviceInformation } from "../../common/ble.interfaces";
 import { HeartRateMonitorMode, IErgConnectionStatus, IRowerSettings } from "../../common/common.interfaces";
+import { versionInfo } from "../../common/data/version";
 import { ConfigManagerService } from "../../common/services/config-manager.service";
 import { ErgConnectionService } from "../../common/services/ergometer/erg-connection.service";
 import { ErgSettingsService } from "../../common/services/ergometer/erg-settings.service";
@@ -33,6 +37,22 @@ import { SnackBarConfirmComponent } from "../../common/snack-bar-confirm/snack-b
 
 import { GeneralSettingsComponent } from "./general-settings.component";
 import { RowingSettingsComponent, RowingSettingsFormGroup } from "./rowing-settings.component";
+
+interface ISettingsExport {
+    schemaVersion: 1;
+    exportedAt: string;
+    appBuildTimestamp: string;
+    profileName: string;
+    deviceInfo: IDeviceInformation;
+    generalSettings: {
+        bleMode: number;
+        logLevel: number;
+        heartRateMonitor: HeartRateMonitorMode;
+        deltaTimeLogging: boolean | undefined;
+        logToSdCard: boolean | undefined;
+    };
+    rowingSettings: Record<string, unknown>;
+}
 
 @Component({
     selector: "app-settings-dialog",
@@ -50,11 +70,17 @@ import { RowingSettingsComponent, RowingSettingsFormGroup } from "./rowing-setti
         GeneralSettingsComponent,
         RowingSettingsComponent,
         AsyncPipe,
+        MatFormField,
+        MatHint,
+        MatLabel,
+        MatInput,
+        ReactiveFormsModule,
     ],
 })
 export class SettingsDialogComponent {
     readonly rowingSettings: Signal<RowingSettingsComponent> = viewChild.required(RowingSettingsComponent);
     readonly generalSettings: Signal<GeneralSettingsComponent> = viewChild.required(GeneralSettingsComponent);
+    readonly exportProfileNameControl: FormControl<string>;
 
     readonly isSaveButtonEnabled: Signal<boolean> = computed((): boolean => {
         const currentTab = this.currentTabIndex();
@@ -89,6 +115,11 @@ export class SettingsDialogComponent {
             deviceInfo: IDeviceInformation;
         },
     ) {
+        this.exportProfileNameControl = new FormControl<string>("", {
+            nonNullable: true,
+            validators: [Validators.required, Validators.maxLength(60)],
+        });
+
         this.breakPoints$.pipe(takeUntilDestroyed()).subscribe((isSmallScreen: boolean): void => {
             if (isSmallScreen) {
                 this.dialogRef.updateSize("90%");
@@ -173,6 +204,48 @@ export class SettingsDialogComponent {
             ))
         ) {
             this.dialogRef.close();
+        }
+    }
+
+    async exportSettings(): Promise<void> {
+        try {
+            const profileName = this.getExportProfileName();
+            if (!profileName) {
+                this.snackBar.open("Please provide a profile name for export", "Dismiss", {
+                    duration: 3000,
+                });
+                return;
+            }
+
+            const generalForm = this.generalSettings().getForm();
+            const rowingForm = this.rowingSettings().getForm();
+
+            const payload: ISettingsExport = {
+                schemaVersion: 1,
+                exportedAt: new Date().toISOString(),
+                appBuildTimestamp: versionInfo.timeStamp,
+                profileName,
+                deviceInfo: this.data.deviceInfo,
+                generalSettings: {
+                    bleMode: generalForm.controls.bleMode.value,
+                    logLevel: generalForm.controls.logLevel.value,
+                    heartRateMonitor: generalForm.controls.heartRateMonitor.value,
+                    deltaTimeLogging: generalForm.controls.deltaTimeLogging.value,
+                    logToSdCard: generalForm.controls.logToSdCard.value,
+                },
+                rowingSettings: rowingForm.getRawValue(),
+            };
+
+            const fileName = this.buildExportFilename(payload.profileName, payload.exportedAt);
+            const blob = new Blob([JSON.stringify(payload, null, 2)], {
+                type: "application/json",
+            });
+
+            await this.shareOrDownload(blob, fileName);
+            this.snackBar.open("Settings exported", "Dismiss", { duration: 3000 });
+        } catch (error) {
+            console.error("exportSettings:", error);
+            this.snackBar.open("Failed to export settings", "Dismiss", { duration: 3000 });
         }
     }
 
@@ -287,5 +360,60 @@ export class SettingsDialogComponent {
                 .pipe(map((): boolean => true)),
             { defaultValue: false },
         );
+    }
+
+    private buildExportFilename(profileName: string, exportedAt: string): string {
+        const safeTimestamp = this.formatExportTimestamp(exportedAt);
+        const safeName = profileName
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "")
+            .slice(0, 40);
+
+        const namePart = safeName.length > 0 ? `-${safeName}` : "";
+
+        return `esprm-settings${namePart}-${safeTimestamp}.json`;
+    }
+
+    private formatExportTimestamp(isoTimestamp: string): string {
+        const date = new Date(isoTimestamp);
+
+        const pad = (value: number): string => value.toString().padStart(2, "0");
+
+        const year = date.getFullYear();
+        const month = pad(date.getMonth() + 1);
+        const day = pad(date.getDate());
+        const hours = pad(date.getHours());
+        const minutes = pad(date.getMinutes());
+
+        return `${year}-${month}-${day}_${hours}-${minutes}`;
+    }
+
+    private getExportProfileName(): string | undefined {
+        const trimmed = this.exportProfileNameControl.value.trim();
+
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+
+    private async shareOrDownload(blob: Blob, fileName: string): Promise<void> {
+        const file = new File([blob], fileName, { type: "application/json" });
+        const shareData: ShareData = {
+            files: [file],
+            title: "ESP Rowing Monitor Settings",
+        };
+
+        if (navigator.canShare && navigator.canShare(shareData)) {
+            await navigator.share(shareData);
+
+            return;
+        }
+
+        const url = window.URL.createObjectURL(blob);
+        const downloadTag = document.createElement("a");
+        downloadTag.href = url;
+        downloadTag.download = fileName;
+        downloadTag.click();
+        window.URL.revokeObjectURL(url);
     }
 }


### PR DESCRIPTION
Hi @Abasz,

i had some time and i'm still fascinated by this project :)

## Description

  This PR adds a dedicated settings export flow so configuration can be shared and discussed more easily.

  The feature was requested in a Discussion (by me) because comparing and talking about settings was cumbersome: values had to be copied manually field by field.
With this change, full settings can be exported in one step and shared as a file.

  Implementation note: parts of this change were prepared with Codex assistance, and I reviewed and tested the behavior locally.

  ## What Changed

  - Added an Export action in the Settings dialog.
  - Added Export Profile Name input on the General tab.
  - Export now produces a JSON payload containing:
      - schemaVersion
      - exportedAt (ISO)
      - appBuildTimestamp (ISO)
      - profileName
      - deviceInfo
      - generalSettings
      - rowingSettings
  - Export filename  includes profile name and ISO-based timestamp
  - Export is only allowed when a device is connected:
      - Export button is disabled if disconnected.
      - Runtime guard in exportSettings() prevents disconnected export.
  - Export profile name is required and validated (required, max length 60).

  ## Why

  - Makes discussion and review of settings practical (Discussion use case).
  - Avoids manual copy/paste of many individual fields.
  - Produces one shareable artifact for GitHub threads, troubleshooting, and comparison.
  
  
[esprm-settings-body-coach-water-rower-2026-02-21T22-23-49-604Z.json](https://github.com/user-attachments/files/25462086/esprm-settings-body-coach-water-rower-2026-02-21T22-23-49-604Z.json)
